### PR TITLE
Add var for IAM role and optionally create a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ module "sftp_user_alice" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70 |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ module "sftp_user_alice" {
 | allowed\_actions | A list of allowed actions for objects in the backend bucket. | `list(string)` | <pre>[<br>  "s3:GetObject",<br>  "s3:GetObjectACL",<br>  "s3:GetObjectVersion",<br>  "s3:PutObject",<br>  "s3:PutObjectACL",<br>  "s3:DeleteObject",<br>  "s3:DeleteObjectVersion"<br>]</pre> | no |
 | home\_directory\_bucket | The S3 Bucket to use as the home directory | <pre>object({<br>    arn = string<br>    id  = string<br>  })</pre> | n/a | yes |
 | home\_directory\_key\_prefix | The home directory key prefix | `string` | `""` | no |
-| role\_name | The name of the IAM role for the SFTP user | `string` | n/a | yes |
+| role\_arn | The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both. | `string` | `""` | no |
+| role\_name | The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both. | `string` | `""` | no |
 | sftp\_server\_id | Server ID of the AWS Transfer Server (aka SFTP Server) | `string` | n/a | yes |
 | ssh\_public\_keys | Public SSH key for the user.  If list is empty, then no SSH Keys are setup to authenticate as the user. | `list(string)` | `[]` | no |
 | tags | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy" "main" {
 resource "aws_transfer_user" "main" {
   server_id      = var.sftp_server_id
   user_name      = var.user_name
-  role           = local.create_iam_role ? aws_iam_role.main[0].arn : role_arn
+  role           = local.create_iam_role ? aws_iam_role.main[0].arn : var.role_arn
   home_directory = format("/%s/%s", var.home_directory_bucket.id, var.home_directory_key_prefix)
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-locals {
-  create_iam_role = var.role_arn == ""
-}
-
 #
 # SFTP
 #
@@ -18,7 +14,7 @@ data "aws_iam_policy_document" "assume_role_policy_doc" {
 }
 
 resource "aws_iam_role" "main" {
-  count = local.create_iam_role ? 1 : 0
+  count = var.role_arn == "" ? 1 : 0
 
   name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
@@ -45,7 +41,7 @@ data "aws_iam_policy_document" "role_policy_doc" {
 }
 
 resource "aws_iam_role_policy" "main" {
-  count = local.create_iam_role ? 1 : 0
+  count = var.role_arn == "" ? 1 : 0
 
   name   = format("%s-policy", aws_iam_role.main[0].name)
   role   = aws_iam_role.main[0].name
@@ -55,7 +51,7 @@ resource "aws_iam_role_policy" "main" {
 resource "aws_transfer_user" "main" {
   server_id      = var.sftp_server_id
   user_name      = var.user_name
-  role           = local.create_iam_role ? aws_iam_role.main[0].arn : var.role_arn
+  role           = var.role_arn == "" ? aws_iam_role.main[0].arn : var.role_arn
   home_directory = format("/%s/%s", var.home_directory_bucket.id, var.home_directory_key_prefix)
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,6 @@ locals {
 #
 
 data "aws_iam_policy_document" "assume_role_policy_doc" {
-  count = local.create_iam_role ? 1 : 0
-
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -23,12 +21,10 @@ resource "aws_iam_role" "main" {
   count = local.create_iam_role ? 1 : 0
 
   name               = var.role_name
-  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc[0].json
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
 }
 
 data "aws_iam_policy_document" "role_policy_doc" {
-  count = local.create_iam_role ? 1 : 0
-
   statement {
     effect = "Allow"
     actions = [
@@ -53,7 +49,7 @@ resource "aws_iam_role_policy" "main" {
 
   name   = format("%s-policy", aws_iam_role.main[0].name)
   role   = aws_iam_role.main[0].name
-  policy = data.aws_iam_policy_document.role_policy_doc[0].json
+  policy = data.aws_iam_policy_document.role_policy_doc.json
 }
 
 resource "aws_transfer_user" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,15 @@ variable "user_name" {
 }
 
 variable "role_name" {
-  description = "The name of the IAM role for the SFTP user"
+  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
   type        = string
+  default     = ""
+}
+
+variable "role_arn" {
+  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
+  type        = string
+  default     = ""
 }
 
 variable "home_directory_bucket" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "~> 0.13.0"
 
   required_providers {
     aws = "~> 2.70"

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.14.0"
 
   required_providers {
-    aws = "~> 3.39"
+    aws = "~> 3.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws = ">= 3.0.0"
+    aws = ">= 2.70"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = "~> 0.14.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = "~> 3.39"
   }
 }


### PR DESCRIPTION
This PR adds the option to specify the ARN of an IAM role defined externally.

It is useful when managing multiple users, to avoid having 1 role per user with the same permissions.