### PR TITLE
Add support to set additional permissions on the user role policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,38 @@
+/**
+ * Creates a user for an AWS Transfer for SFTP endpoint.
+ *
+ * Creates the following resources:
+ *
+ * * AWS Transfer user
+ * * IAM policy for the user to access S3.
+ * * SSH Keys attached to the Transfer user.
+ *
+ * ## Usage
+ * ```hcl
+ * module "sftp_user_alice" {
+ *   source                = "trussworks/sftp-user/aws"
+ *   version               = "~> 1.0.0"
+ *
+ *   sftp_server_id            = aws_transfer_server.my_app_sftp.id
+ *   ssh_public_keys           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 example@example.com"]
+ *   user_name                 = "alice"
+ *   role_name                 = "alice-sftp-role"
+ *   home_directory_bucket     = "myapp_sftp_bucket"
+ *   home_directory_key_prefix = "alice/"
+ *   allowed_actions = [
+ *     "s3:GetObject",
+ *     "s3:GetObjectACL",
+ *     "s3:PutObject",
+ *     "s3:PutObjectACL",
+ *   ]
+ *   tags = {
+ *     Application = "my_app"
+ *     Environment = "prod"
+ *   }
+ * }
+ * ```
+ */
+
 #
 # SFTP
 #
@@ -14,14 +49,13 @@ data "aws_iam_policy_document" "assume_role_policy_doc" {
 }
 
 resource "aws_iam_role" "main" {
-  count = var.role_arn == "" ? 1 : 0
-
   name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
 }
 
 data "aws_iam_policy_document" "role_policy_doc" {
   statement {
+    sid    = "S3ListPermissions"
     effect = "Allow"
     actions = [
       "s3:ListBucket",
@@ -32,26 +66,36 @@ data "aws_iam_policy_document" "role_policy_doc" {
     ]
   }
   statement {
+    sid     = "S3AllowedPermissions"
     effect  = "Allow"
     actions = var.allowed_actions
     resources = [
       format("%s/%s*", var.home_directory_bucket.arn, var.home_directory_key_prefix)
     ]
   }
+  
+  dynamic "statement" {
+    for_each = var.additional_role_statements
+
+    content {
+      sid       = statement.value["sid"]
+      effect    = statement.value["effect"]
+      actions   = statement.value["actions"]
+      resources = statement.value["resources"]
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "main" {
-  count = var.role_arn == "" ? 1 : 0
-
-  name   = format("%s-policy", aws_iam_role.main[0].name)
-  role   = aws_iam_role.main[0].name
+  name   = format("%s-policy", aws_iam_role.main.name)
+  role   = aws_iam_role.main.name
   policy = data.aws_iam_policy_document.role_policy_doc.json
 }
 
 resource "aws_transfer_user" "main" {
   server_id      = var.sftp_server_id
   user_name      = var.user_name
-  role           = var.role_arn == "" ? aws_iam_role.main[0].arn : var.role_arn
+  role           = aws_iam_role.main.arn
   home_directory = format("/%s/%s", var.home_directory_bucket.id, var.home_directory_key_prefix)
 
   tags = merge(
@@ -63,8 +107,7 @@ resource "aws_transfer_user" "main" {
 }
 
 resource "aws_transfer_ssh_key" "main" {
-  count = length(var.ssh_public_keys)
-
+  count     = length(var.ssh_public_keys)
   server_id = var.sftp_server_id
   user_name = aws_transfer_user.main.user_name
   body      = var.ssh_public_keys[count.index]

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@ data "aws_iam_policy_document" "assume_role_policy_doc" {
 }
 
 resource "aws_iam_role" "main" {
+  count = var.role_arn == "" ? 1 : 0
+
   name               = var.role_name
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy_doc.json
 }
@@ -52,6 +54,8 @@ data "aws_iam_policy_document" "role_policy_doc" {
 }
 
 resource "aws_iam_role_policy" "main" {
+  count = var.role_arn == "" ? 1 : 0
+
   name   = format("%s-policy", aws_iam_role.main.name)
   role   = aws_iam_role.main.name
   policy = data.aws_iam_policy_document.role_policy_doc.json
@@ -60,7 +64,7 @@ resource "aws_iam_role_policy" "main" {
 resource "aws_transfer_user" "main" {
   server_id      = var.sftp_server_id
   user_name      = var.user_name
-  role           = aws_iam_role.main.arn
+  role           = var.role_arn == "" ? aws_iam_role.main[0].arn : var.role_arn
   home_directory = format("/%s/%s", var.home_directory_bucket.id, var.home_directory_key_prefix)
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -1,38 +1,3 @@
-/**
- * Creates a user for an AWS Transfer for SFTP endpoint.
- *
- * Creates the following resources:
- *
- * * AWS Transfer user
- * * IAM policy for the user to access S3.
- * * SSH Keys attached to the Transfer user.
- *
- * ## Usage
- * ```hcl
- * module "sftp_user_alice" {
- *   source                = "trussworks/sftp-user/aws"
- *   version               = "~> 1.0.0"
- *
- *   sftp_server_id            = aws_transfer_server.my_app_sftp.id
- *   ssh_public_keys           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 example@example.com"]
- *   user_name                 = "alice"
- *   role_name                 = "alice-sftp-role"
- *   home_directory_bucket     = "myapp_sftp_bucket"
- *   home_directory_key_prefix = "alice/"
- *   allowed_actions = [
- *     "s3:GetObject",
- *     "s3:GetObjectACL",
- *     "s3:PutObject",
- *     "s3:PutObjectACL",
- *   ]
- *   tags = {
- *     Application = "my_app"
- *     Environment = "prod"
- *   }
- * }
- * ```
- */
-
 #
 # SFTP
 #

--- a/main.tf
+++ b/main.tf
@@ -56,8 +56,8 @@ data "aws_iam_policy_document" "role_policy_doc" {
 resource "aws_iam_role_policy" "main" {
   count = var.role_arn == "" ? 1 : 0
 
-  name   = format("%s-policy", aws_iam_role.main.name)
-  role   = aws_iam_role.main.name
+  name   = format("%s-policy", aws_iam_role.main[0].name)
+  role   = aws_iam_role.main[0].name
   policy = data.aws_iam_policy_document.role_policy_doc.json
 }
 
@@ -77,6 +77,7 @@ resource "aws_transfer_user" "main" {
 
 resource "aws_transfer_ssh_key" "main" {
   count     = length(var.ssh_public_keys)
+  
   server_id = var.sftp_server_id
   user_name = aws_transfer_user.main.user_name
   body      = var.ssh_public_keys[count.index]

--- a/main.tf
+++ b/main.tf
@@ -76,8 +76,8 @@ resource "aws_transfer_user" "main" {
 }
 
 resource "aws_transfer_ssh_key" "main" {
-  count     = length(var.ssh_public_keys)
-  
+  count = length(var.ssh_public_keys)
+
   server_id = var.sftp_server_id
   user_name = aws_transfer_user.main.user_name
   body      = var.ssh_public_keys[count.index]

--- a/variables.tf
+++ b/variables.tf
@@ -4,15 +4,19 @@ variable "user_name" {
 }
 
 variable "role_name" {
-  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
+  description = "The name of the IAM role for the SFTP user"
   type        = string
-  default     = ""
 }
 
-variable "role_arn" {
-  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
-  type        = string
-  default     = ""
+variable "additional_role_statements" {
+  type        = map(object({
+    sid       = string
+    effect    = string
+    actions   = list(string)
+    resources = list(string)
+  }))
+  description = "List of additional statements that will be added to the role assigned to the SFTP user."
+  default     = {}
 }
 
 variable "home_directory_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "role_name" {
   type        = string
 }
 
+variable "role_arn" {
+  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
+  type        = string
+  default     = ""
+}
+
 variable "additional_role_statements" {
   type        = map(object({
     sid       = string

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,12 @@ variable "user_name" {
 }
 
 variable "role_name" {
-  description = "The name of the IAM role for the SFTP user"
+  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
   type        = string
 }
 
 variable "role_arn" {
-  description = "The name of the IAM role for the SFTP user. Either `role_name` or `role_arn` must be provided, not both."
+  description = "The ARN of a custom IAM role for the SFTP user."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
This is convenient, for instance, if the bucket uses server-side encryption by means of a KMS CMK. In that case, AWS Transfer will need permission to perform read/write operations on the bucket.